### PR TITLE
Version bump for Release 114

### DIFF
--- a/sql/patch_113_114_a.sql
+++ b/sql/patch_113_114_a.sql
@@ -1,0 +1,27 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2024] EMBL-European Bioinformatics Institute
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+# patch_113_114_a.sql
+#
+# Title: Update schema version.
+#
+# Description:
+#   Update schema_version in meta table to 114.
+
+UPDATE meta SET meta_value='114' WHERE meta_key='schema_version';
+
+# Patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value)
+  VALUES (NULL, 'patch', 'patch_113_114_a.sql|schema_version');

--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -30,14 +30,11 @@ CREATE TABLE `meta` (
 # Add schema type and schema version to the meta table
 INSERT INTO meta (meta_key, meta_value) VALUES
   ('schema_type', 'ontology'),
-  ('schema_version', '113');
+  ('schema_version', '114');
 
 # Patches included in this schema file
 INSERT INTO meta (meta_key, meta_value)
-  VALUES ('patch', 'patch_112_113_a.sql|schema_version');
-
-INSERT INTO meta (meta_key, meta_value)
-  VALUES ('patch', 'patch_112_113_b.sql|Ensure meta_value is not null');
+  VALUES ('patch', 'patch_113_114_a.sql|schema_version');
 
 CREATE TABLE `ontology` (
   `ontology_id` int(10) unsigned NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
Version bump for Release 114. SQL patch file added and `tables.sql` has been updated (same as in [113](https://github.com/Ensembl/ensembl-ontology-schema/pull/19/files)).